### PR TITLE
Fix path to the c++ file

### DIFF
--- a/script.py
+++ b/script.py
@@ -10,7 +10,7 @@ from clang import utils
 cindex = cindex38
 TU = cindex.TranslationUnit
 ClangUtils = utils.ClangUtils
-filename = path.abspath(os.path.join(path.dirname(__file__), "test.cpp"))
+filename = path.abspath(path.join(path.dirname(__file__), "test.cpp"))
 clang_dir = ClangUtils.find_libclang_dir("clang++")
 if not cindex.Config.loaded:
     cindex.Config.set_library_path(clang_dir)

--- a/script.py
+++ b/script.py
@@ -10,7 +10,7 @@ from clang import utils
 cindex = cindex38
 TU = cindex.TranslationUnit
 ClangUtils = utils.ClangUtils
-filename = path.abspath(path.dirname(__file__) + "/test.cpp")
+filename = path.abspath(os.path.join(path.dirname(__file__), "test.cpp"))
 clang_dir = ClangUtils.find_libclang_dir("clang++")
 if not cindex.Config.loaded:
     cindex.Config.set_library_path(clang_dir)


### PR DESCRIPTION
Use proper way of concatenating path. Otherwise things fail depending
on what **file** is set too ('.script.py' would work while 'script.py'
wouldn't).
